### PR TITLE
Automated Changelog Entry for 0.1.6 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.6
+
+([Full Changelog](https://github.com/trungleduc/jupyter_app_launcher/compare/v0.1.5...1633002852cafdc3bd97165e86bab9967f3474c4))
+
+### Merged PRs
+
+- Substitute environment variables in URL source [#28](https://github.com/trungleduc/jupyter_app_launcher/pull/28) ([@sinkuladis](https://github.com/sinkuladis))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/trungleduc/jupyter_app_launcher/graphs/contributors?from=2022-10-13&to=2023-04-25&type=c))
+
+[@sinkuladis](https://github.com/search?q=repo%3Atrungleduc%2Fjupyter_app_launcher+involves%3Asinkuladis+updated%3A2022-10-13..2023-04-25&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.1.5
 
 ([Full Changelog](https://github.com/trungleduc/jupyter_app_launcher/compare/v0.1.4...7040059d7c75904332f7d08a1f1e374e2ef3c117))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/trungleduc/jupyter_app_launcher/graphs/contributors?from=2022-10-10&to=2022-10-13&type=c))
 
 [@trungleduc](https://github.com/search?q=repo%3Atrungleduc%2Fjupyter_app_launcher+involves%3Atrungleduc+updated%3A2022-10-10..2022-10-13&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.1.4
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">jupyter_app_launcher</h1>
 
-[![Github Actions Status](https://github.com/trungleduc/jupyter_app_launcher/workflows/Build/badge.svg)](https://github.com/trungleduc/jupyter_app_launcher/actions/workflows/build.yml) [![Documentation Status](https://readthedocs.org/projects/jupyter-app-launcher/badge/?version=latest)](https://jupyter-app-launcher.readthedocs.io/en/latest/?badge=latest) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/trungleduc/jupyter_app_launcher/main?urlpath=lab) [![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://trungleduc.github.io/jupyter_app_launcher/lab/index.html) [![GitHub license](https://badgen.net/github/license/trungleduc/jupyter_app_launcher)](https://github.com/trungleduc/jupyter_app_launcher/blob/master/LICENSE)
+[![Github Actions Status](https://github.com/trungleduc/jupyter_app_launcher/workflows/Build/badge.svg)](https://github.com/trungleduc/jupyter_app_launcher/actions/workflows/build.yml) [![Documentation Status](https://readthedocs.org/projects/jupyter-app-launcher/badge/?version=latest)](https://jupyter-app-launcher.readthedocs.io/en/latest/?badge=latest) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/trungleduc/jupyter_app_launcher/main?urlpath=lab) [![JupyterLite](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://trungleduc.github.io/jupyter_app_launcher/lab/index.html)
 
 <h2 align="center"> A JupyterLab extension to create custom launcher entries </h2>
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.6 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | trungleduc/jupyter_app_launcher  |
| Branch  | main  |
| Version Spec | 0.1.6 |
| Since | v0.1.5 |