### PR TITLE
Use full path when creating new notebook 

### DIFF
--- a/src/factories/notebook/notebook_factory.ts
+++ b/src/factories/notebook/notebook_factory.ts
@@ -30,7 +30,8 @@ export class NotebookFactory implements IPanelFactory {
     await fileBrowser.model.upload(fileBlob);
     const configArgs: IDict = config.args ?? {};
     const factory = configArgs['widget-type'] ?? 'default';
-    const doc = await documentManager.openOrReveal(newName, factory);
+    const newPath = `${fileBrowser.model.path}/${newName}`;
+    const doc = await documentManager.openOrReveal(newPath, factory);
     if (!doc) {
       console.error(`Failed to create widget with ${factory} factory`);
       return;


### PR DESCRIPTION
I think this fixes #72 by using the full path, rather than just the name of the notebook, when creating a new notebook.

The problem reported in #72 is that the notebook is *always* created in the root folder that jupyter was launched from (or at least that is where the file creation is attempted). If you are in a subfolder and the notebook does *not* already exist in the root folder, an error is raised, as reported in #72.

The other issue mentioned in #72 -- that sometimes the notebook launches but is connected to a copy in the root folder -- happens if you try to make the notebook in a subfolder and it also exists in the root folder. In that case `openOrReveal` opens up the one that exists in the root folder, though one also ends up with a copy in the working folder.

No idea if this is the right fix 😬 