### PR TITLE
Allow JUPYTER_APP_LAUNCHER_PATH to contain multiple paths

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -82,7 +82,6 @@ Here is a summary of the steps to cut a new release:
 - If the repo generates PyPI release(s), create a scoped PyPI [token](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github). We recommend using a scoped token for security reasons.
 
 - You can store the token as `PYPI_TOKEN` in your fork's `Secrets`.
-
   - Advanced usage: if you are releasing multiple repos, you can create a secret named `PYPI_TOKEN_MAP` instead of `PYPI_TOKEN` that is formatted as follows:
 
     ```text

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -35,7 +35,7 @@ If under the `jupyter_app_launcher` directory of these paths, YAML files (`.yaml
   /home/***/mambaforge/envs/appdev/share/jupyter/jupyter_app_launcher/jp_app_launcher_my_app.yml
   /home/***/.local/share/jupyter/jupyter_app_launcher/jp_app_launcher_my_other_app.yml
 
-In addition to this behavior, `jupyter_app_launcher` also loads the YAML files with names starting with `jp_app_launcher` in the directory where JupyterLab was started, and also in the path defined by the ``JUPYTER_APP_LAUNCHER_PATH`` environment variable.
+In addition to this behavior, `jupyter_app_launcher` also loads the YAML files with names starting with `jp_app_launcher` in the directory where JupyterLab was started, and also in the path defined by the ``JUPYTER_APP_LAUNCHER_PATH`` environment variable, which can contain multiple paths separated by colon (`:`).
 
 .. note::
   This extension only reads the configuration file when JupyterLab starts. Users need to restart JupyterLab after changing the config file.

--- a/jupyter_app_launcher/handlers.py
+++ b/jupyter_app_launcher/handlers.py
@@ -68,7 +68,7 @@ class JupyterAppLauncher(APIHandler):
             config_path.append(os.getcwd())
             app_launcher_path_env = getenv("JUPYTER_APP_LAUNCHER_PATH", None)
             if app_launcher_path_env:
-                config_path.extend(app_launcher_path_env.split(':'))
+                config_path.extend(app_launcher_path_env.split(":"))
 
             for path in config_path:
                 if not osp.exists(path):

--- a/jupyter_app_launcher/handlers.py
+++ b/jupyter_app_launcher/handlers.py
@@ -68,7 +68,7 @@ class JupyterAppLauncher(APIHandler):
             config_path.append(os.getcwd())
             app_launcher_path_env = getenv("JUPYTER_APP_LAUNCHER_PATH", None)
             if app_launcher_path_env:
-                config_path.append(app_launcher_path_env)
+                config_path.extend(app_launcher_path_env.split(':'))
 
             for path in config_path:
                 if not osp.exists(path):


### PR DESCRIPTION
Separated by `:` like other path variables.

The `osp.exists` check below will filter out any empty path segments.