### PR TITLE
:books: Update usage instructions for svg icon

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -82,7 +82,6 @@ Here is a summary of the steps to cut a new release:
 - If the repo generates PyPI release(s), create a scoped PyPI [token](https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/#saving-credentials-on-github). We recommend using a scoped token for security reasons.
 
 - You can store the token as `PYPI_TOKEN` in your fork's `Secrets`.
-
   - Advanced usage: if you are releasing multiple repos, you can create a secret named `PYPI_TOKEN_MAP` instead of `PYPI_TOKEN` that is formatted as follows:
 
     ```text

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -116,7 +116,7 @@ The common fields of the configurations are: ``title``, ``description``  ``icon`
 
 - ``title``: Title of the launcher entry.
 - ``description`` (Optional): Description of the launcher entry. It will be shown on mouse hover.
-- ``icon`` (Optional): Path to the icon of the launcher entry. If it is not defined, the initials of the title will be used as the icon.
+- ``icon`` (Optional): Path to the SVG icon of the launcher entry. For example: ``icon: /usr/share/icons/my_icon.svg``. If it is not defined, the initials of the title will be used as the icon. 
 - ``catalog`` (Optional): Catalog of the launcher entry, entry with the same catalog will be grouped in the same group in the launcher, If it is not defined, `Jupyter App` catalog will be used.
 
 Other fields will have different meanings depending on the entry type. In this section, we will detail these fields for each type of entry.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -116,7 +116,7 @@ The common fields of the configurations are: ``title``, ``description``  ``icon`
 
 - ``title``: Title of the launcher entry.
 - ``description`` (Optional): Description of the launcher entry. It will be shown on mouse hover.
-- ``icon`` (Optional): Path to the SVG icon of the launcher entry. For example: ``icon: /usr/share/icons/my_icon.svg``. If it is not defined, the initials of the title will be used as the icon. 
+- ``icon`` (Optional): Path to the SVG icon of the launcher entry. For example: ``icon: /usr/share/icons/my_icon.svg``. If it is not defined, the initials of the title will be used as the icon.
 - ``catalog`` (Optional): Catalog of the launcher entry, entry with the same catalog will be grouped in the same group in the launcher, If it is not defined, `Jupyter App` catalog will be used.
 
 Other fields will have different meanings depending on the entry type. In this section, we will detail these fields for each type of entry.


### PR DESCRIPTION
# Description

This PR solves issue #35 by specifying that only SVG icons can be used. An example was also added to this documentation.